### PR TITLE
RBT-117-group-page-reload-bug Fixed group page reload issue

### DIFF
--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -22,6 +22,7 @@ export default function GroupPage({ user, token, stream }) {
 	const [joinGroupInformation, setJoinGroupInformation] = useState(null);
 	const [groups, setGroups] = useState(null);
 	const [groupInvitations, setGroupInvitations] = useState(null);
+	const [showChat, setShowChat] = useState(false)
 	// const [groupCreated, setGroupCreated] = useState(false)
 
 	const getGroupCode = function () {
@@ -69,6 +70,10 @@ export default function GroupPage({ user, token, stream }) {
 		getGroupCode();
 		viewGroups();
 		viewGroupInvitations();
+		setTimeout(() => {
+			setShowChat(true)
+			console.log("TIMEOUT")
+		}, 300)
 	}, []);
 
 	// this part is just necessary for the create group form
@@ -104,13 +109,14 @@ export default function GroupPage({ user, token, stream }) {
 					<Col md={8}>
 						{/* {groups || groupInformation
 						? */}
-						<Chatroom
+						{ showChat &&
+							<Chatroom
 							user={user}
 							token={token}
 							stream={stream}
 							createGroupInformation={createGroupInformation}
 							joinGroupInformation={joinGroupInformation}
-						/>
+						/> }
 						{/* : null
 						} */}
 					</Col>


### PR DESCRIPTION
After doing some testing, it looked like the issue was that when the page loaded, the chatroom component was trying to render before all of the props had been loaded (not quite sure how that happens honestly) so I added a setTimeout on the group page that waits 300ms before rendering the chatroom, giving the page enough time to load its props before trying to render the chat. After adding that fix, I haven't been able to recreate the page reload bug, so I think its a done deal.