### PR TITLE
Rbt 143 send current attendees and if owner for each event

### DIFF
--- a/backend/game_night_app/serializers.py
+++ b/backend/game_night_app/serializers.py
@@ -2,12 +2,13 @@ from rest_framework import serializers
 from game_night_app.models import Event
 
 class EventSerializer(serializers.ModelSerializer):
+    peeps = serializers.CharField()
     class Meta:
         model = Event
-        fields = '__all__'
+        fields = ('name','peeps')
 
-class EventListSerializer(serializers.ModelSerializer):
-    events = EventSerializer(many=True)
-    class Meta:
-        model= Event
-        fields = '__all__'
+# class EventListSerializer(serializers.ModelSerializer):
+#     events = EventSerializer(many=True)
+#     class Meta:
+#         model= Event
+#         fields = '__all__'

--- a/backend/game_night_app/urls.py
+++ b/backend/game_night_app/urls.py
@@ -26,7 +26,5 @@ urlpatterns = [
     path('userevents/<int:id>', views.userevents_byid),
     path('streamapi', views.stream_api),
     path('events/create', views.create_event),
-    # user events -- has only the necessary information for event table
-    path('userevents/table', views.user_events_table_data),
 
 ]

--- a/frontend/src/components/Calendar/Calendar.jsx
+++ b/frontend/src/components/Calendar/Calendar.jsx
@@ -37,7 +37,7 @@ export default function Calendar({data}) {
           right: 'dayGridMonth,timeGridWeek,timeGridDay'
         }}
         events={ 
-          data.map((event) => ({title: event.fields.name, start: event.fields.start_time, end: event.fields.end_time , allDay: event.fields.all_day, url: `/#/events/${event.fields.code}`}))
+          data.map((event) => ({title: event.name, start: event.start_time, end: event.end_time , allDay: event.all_day, url: `/#/events/${event.code}`}))
         }
       />
     </div>

--- a/frontend/src/components/List/EventDetailList.jsx
+++ b/frontend/src/components/List/EventDetailList.jsx
@@ -65,7 +65,7 @@ export default function EventDetailList({eventDetail, games, startTime, endTime}
         <li className="flex align-items-center py-3 px-2 border-top-1 border-300 flex-wrap">
             <div className="text-500 w-6 md:w-2 font-medium">Current Number of Attendees / Max Attendees</div>
             <div className="text-900 w-full md:w-8 md:flex-order-0 flex-order-1">
-            {'?' + ' / ' + eventDetail.max_attendees}
+            {eventDetail.peeps + ' / ' + eventDetail.max_attendees}
             </div>
             <div className="w-6 md:w-2 flex justify-content-end">
                 <Button label="Edit" icon="pi pi-pencil" className="p-button-text" />

--- a/frontend/src/components/Tables/EventsTable/EventsTable.jsx
+++ b/frontend/src/components/Tables/EventsTable/EventsTable.jsx
@@ -19,13 +19,14 @@ export const EventsTable = () => {
 
 	useEffect(() => {
 		axios
-		.get('/userevents/table')
+		.get('/userevents')
 		.then((response) => {
 			let data = []
 			for(let item in response.data) {
-				data.push(response.data[item].fields)
+				data.push(response.data[item])
 			}
 			setEvents(data)
+			console.log(data)
 			
 		})
 		.catch((error) => {console.log('ERROR', error);})

--- a/frontend/src/pages/EventDetailPage.jsx
+++ b/frontend/src/pages/EventDetailPage.jsx
@@ -21,11 +21,11 @@ export default function EventDetailPage() {
 		axios
 		.get(`/userevents/${eventId}`)
 		.then((response) => {
-            console.log('response data', response.data[0].fields)
-			setGames(Object.values(response.data[0].fields.games))
-			setStartTime(moment(response.data[0].fields.start_time).format('MMMM Do YYYY, h:mm a'))
-			setEndTime(moment(response.data[0].fields.end_time).format('MMMM Do YYYY, h:mm a'))
-			setEventDetail(response.data[0].fields)
+            console.log('response data', response.data[0])
+			setGames(Object.values(response.data[0].games))
+			setStartTime(moment(response.data[0].start_time).format('MMMM Do YYYY, h:mm a'))
+			setEndTime(moment(response.data[0].end_time).format('MMMM Do YYYY, h:mm a'))
+			setEventDetail(response.data[0])
 		})
 	}, [])
 


### PR DESCRIPTION
changes:
 - Removed duplicated endpoint of user events
 - changed the response of userevents and userevents_by_id to include the current nº of attendees and  a field "owner_true" which is 0 when user is not owner and 1 or more if they are.
 - fixed all the frontend that receives the data from both endpoints
 - added current nº of attendees to the event detail page 